### PR TITLE
Enabled automatic start of the applications by docker using CMD

### DIFF
--- a/docs/README_TheoryOfOperations.md
+++ b/docs/README_TheoryOfOperations.md
@@ -23,7 +23,7 @@ each of two drive motors. Finally, it can set the position of
 sixteen servoes.
 
 Measurement and status information from the robot is sent to
-browser in a continuous stream. The browser extracts individual
+the browser in a continuous stream. The browser extracts individual
 values and uses them to update widgets on the page. The video
 frames are displayed as the background of the browser page.
 

--- a/ros2ws/Dockerfile.roboquest_core
+++ b/ros2ws/Dockerfile.roboquest_core
@@ -1,6 +1,6 @@
 FROM ros:humble-ros-base
 
-LABEL version="6"
+LABEL version="7"
 LABEL description="ROS2 RoboQuest core"
 LABEL maintainer="Bill Mania <bill@manialabs.us>"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -38,3 +38,4 @@ RUN source /opt/ros/humble/setup.bash \
     && colcon build
 
 ENTRYPOINT ["/bin/bash", "--login"]
+CMD ["/usr/src/ros2ws/src/roboquest_core/scripts/start.sh"]

--- a/ros2ws/Dockerfile.roboquest_ui
+++ b/ros2ws/Dockerfile.roboquest_ui
@@ -1,6 +1,6 @@
 FROM ros:humble-ros-base
 
-LABEL version="7"
+LABEL version="8"
 LABEL description="ROS2 RoboQuest frontend"
 LABEL maintainer="Bill Mania <bill@manialabs.us>"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -82,3 +82,4 @@ RUN colcon build --packages-select rq_msgs roboquest_ui
 
 WORKDIR /usr/src/ros2ws
 ENTRYPOINT ["/bin/bash", "--login"]
+CMD ["/usr/src/ros2ws/src/roboquest_ui/scripts/start.sh"]


### PR DESCRIPTION
Modified both Dockerfile-s to use CMD and a start.sh script to automatically start the applications.

Added support for private docker image registry.

Tested and verified with both a desktop and mobile browser.

Requires both [core PR 1](https://github.com/billmania/roboquest_core/pull/1) and [ui PR 4](https://github.com/billmania/roboquest_ui/pull/4)