### PR TITLE
Updated roboquest_core and roboquest_ui to version 13

### DIFF
--- a/docs/README_TheoryOfOperations.md
+++ b/docs/README_TheoryOfOperations.md
@@ -58,7 +58,7 @@ Docker version 23.0.5.
 The robotics framework is ROS2 Humble running in several Docker
 containers. The programming languages are Python 3.9 and
 ECMAScript 5 (I think) with Google V8 version 10. The server side
-JavaScript is executed by NodeJS Hydrogen (18) and uses rclnodejs
+JavaScript is executed by NodeJS Hydrogen (18.17.1) and uses rclnodejs
 version 0.22.1.
 
 Communications with the browser use ExpressJS version 4.18.2 and

--- a/ros2ws/Dockerfile.roboquest_core
+++ b/ros2ws/Dockerfile.roboquest_core
@@ -1,6 +1,6 @@
 FROM ros:humble-ros-base
 
-LABEL version="12"
+LABEL version="13"
 LABEL description="ROS2 RoboQuest core"
 LABEL maintainer="Bill Mania <bill@manialabs.us>"
 ARG DEBIAN_FRONTEND=noninteractive

--- a/ros2ws/Dockerfile.roboquest_ui
+++ b/ros2ws/Dockerfile.roboquest_ui
@@ -76,6 +76,9 @@ WORKDIR /usr/src/ros2ws/src/roboquest_ui
 #
 RUN npm ci
 
+WORKDIR /usr/src/ros2ws/src/roboquest_ui/public
+RUN npm ci
+
 COPY src/roboquest_ui/generate_messages.sh generate_messages.sh
 RUN ./generate_messages.sh ${ARCH}
 

--- a/ros2ws/Dockerfile.roboquest_ui
+++ b/ros2ws/Dockerfile.roboquest_ui
@@ -1,6 +1,6 @@
 FROM ros:humble-ros-base
 
-LABEL version="12"
+LABEL version="13"
 LABEL description="ROS2 RoboQuest frontend"
 LABEL maintainer="Bill Mania <bill@manialabs.us>"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -24,14 +24,14 @@ RUN apt-get install -y \
     python3-colcon-ros
 
 WORKDIR /tmp
-RUN curl --output node-v18.16.0-linux-${ARCH}.tar.gz \
-      https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-${ARCH}.tar.gz \
+RUN curl --output node-v18.17.1-linux-${ARCH}.tar.gz \
+      https://nodejs.org/dist/v18.17.1/node-v18.17.1-linux-${ARCH}.tar.gz \
       && curl --output SHASUM256.txt \
-           https://nodejs.org/dist/v18.16.0/SHASUMS256.txt
-RUN grep node-v18.16.0-linux-${ARCH}.tar.gz SHASUM256.txt \
+           https://nodejs.org/dist/v18.17.1/SHASUMS256.txt
+RUN grep node-v18.17.1-linux-${ARCH}.tar.gz SHASUM256.txt \
       | sha256sum -c -
 WORKDIR /usr/local
-RUN tar xzf /tmp/node-v18.16.0-linux-${ARCH}.tar.gz
+RUN tar xzf /tmp/node-v18.17.1-linux-${ARCH}.tar.gz
 
 WORKDIR /usr/src/ros2ws/src
 RUN git clone -b main https://github.com/billmania/rq_msgs.git
@@ -59,7 +59,7 @@ WORKDIR /usr/src/ros2ws
 #
 RUN colcon build --packages-select rq_msgs
 
-ENV PATH="${PATH}:/usr/local/node-v18.16.0-linux-${ARCH}/bin"
+ENV PATH="${PATH}:/usr/local/node-v18.17.1-linux-${ARCH}/bin"
 WORKDIR /usr/src/ros2ws/src/roboquest_ui
 #
 # Now the NodeJS modules required by roboquest_ui must be installed. This


### PR DESCRIPTION
1. support in roboquest_core for Pi HAT v2
2. roboquest_core to v13
3. roboquest_ui to v13
4. upgrade Dockerfile.roboquest_ui to NodeJS LTS 18.17.1

[roboquest_core PR 18](https://github.com/billmania/roboquest_core/pull/18)