### PR TITLE
Run npm install in two directories for roboquest_ui

### DIFF
--- a/ros2ws/Dockerfile.roboquest_ui
+++ b/ros2ws/Dockerfile.roboquest_ui
@@ -76,6 +76,9 @@ WORKDIR /usr/src/ros2ws/src/roboquest_ui
 #
 RUN npm ci
 
+WORKDIR /usr/src/ros2ws/src/roboquest_ui/public
+RUN npm ci
+
 COPY src/roboquest_ui/generate_messages.sh generate_messages.sh
 RUN ./generate_messages.sh ${ARCH}
 


### PR DESCRIPTION
This will be roboquest_ui version 13.

There are some third-party JavaScript libraries which are only needed by the browser. Since the browser may not have Internet connectivity when running the RoboQuest UI, the libraries must be served by the robot's web server. In order to keep the configuration of the web server as simple as possible AND not commit any third party libraries to the roboquest_ui repo, the Dockerfile was adjusted to work with two separate npm package.json files.

Requires [roboquest_ui PR 21](https://github.com/billmania/roboquest_ui/pull/21)