### PR TITLE
Added the Python module PyMLX90614 to the rq_core Dockerfile

### DIFF
--- a/ros2ws/Dockerfile.roboquest_core
+++ b/ros2ws/Dockerfile.roboquest_core
@@ -1,6 +1,6 @@
 FROM ros:humble-ros-base
 
-LABEL version="24"
+LABEL version="25rc1"
 LABEL description="ROS2 RoboQuest core"
 LABEL maintainer="Bill Mania <bill@manialabs.us>"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -38,7 +38,7 @@ RUN apt-get update \
       ros-humble-usb-cam
 RUN apt-get update \
     && apt-get install -y python3-pip
-RUN pip3 install smbus2
+RUN pip3 install smbus2 PyMLX90614
 
 WORKDIR /usr/src/ros2ws
 RUN mkdir src


### PR DESCRIPTION
rq_core v25

The rq_core docker image now includes the PyMLX90614 Python module. That addition allows the I2C MLX90614 temperature sensor to be integrated via the [User nodes](https://github.com/billmania/roboquest_core/wiki/User-nodes) and [Adding I2C devices](https://github.com/billmania/roboquest_core/wiki/Adding-I2C-devices) procedures, without using the rq_addons docker container. The intent is to simplify the process for adding a pre-defined collection of sensors. Since the User nodes procedure already includes a mechanism for automatically starting the user nodes, this enhancement eliminates the need for a separate container startup solution.