### PR TITLE
Add camera configuration stuff for the ArduCam CSI camera and support rpi-image-gen

### DIFF
--- a/ros2ws/Dockerfile.roboquest_addons
+++ b/ros2ws/Dockerfile.roboquest_addons
@@ -1,12 +1,11 @@
 FROM ros:humble-ros-base
-#FROM ubuntu:noble
 
-LABEL version="3"
+LABEL version="4rc2"
 LABEL description="ROS2 RoboQuest addons"
 LABEL maintainer="Bill Mania <bill@manialabs.us>"
 ARG DEBIAN_FRONTEND=noninteractive
 
-#RUN echo "source /opt/ros/humble/setup.bash" >> /etc/profile
+RUN echo "source /opt/ros/humble/setup.bash" >> /etc/profile
 
 RUN ln -sf /bin/bash /bin/sh
 
@@ -15,57 +14,28 @@ SHELL ["/bin/bash", "--login", "-c"]
 RUN apt-get update \
     && apt-get upgrade -y
 RUN apt-get install -y \
-    vim
+    vim \
+    ros-humble-xacro \
+    ros-humble-joint-state-publisher
 
 #
 # For recognizing APRIL tags.
 #
 # requires FROM ros:humble-ros-base
-#WORKDIR /usr/src/ros2ws
-#RUN apt-get install -y ros-humble-apriltag-ros
+WORKDIR /usr/src/ros2ws
+RUN apt-get install -y ros-humble-apriltag-ros
 
 #
 # For the SLAMTEC RPLiDAR unit.
 #
 # requires FROM ros:humble-ros-base
-#RUN git clone -b ros2 https://github.com/Slamtec/rplidar_ros.git
-#WORKDIR /usr/src/ros2ws
-#COPY src/roboquest_addons src/roboquest_addons
-#RUN source /opt/ros/humble/setup.bash \
-#    && colcon build --symlink-install
-
-
-#
-# For the VL53L0X I2C range-finding sensor
-#
-# requires FROM ubuntu:noble
-#RUN apt-get install -y \
-#    python3-rpi.gpio \
-#    python3-smbus2 \
-#    python3-pip \
-#    i2c-tools \
-#    lsof
-#
-# The following is actually
-# https://github.com/Gadgetoid/VL53L0X-python.git, which itself
-# is a fork of
-# https://github.com/johnbryanmoore/VL53L0X_rasp_python
-#
-#RUN pip3 install git+https://github.com/pimoroni/VL53L0X-python.git
-
-#
-# For the MLX90614 temperature sensor
-#
-# requires FROM ubuntu:noble
-RUN apt-get install -y \
-    python3-pip \
-    python3-venv \
-    i2c-tools \
-    lsof
-WORKDIR /usr/src
-COPY src/roboquest_addons roboquest_addons
-RUN python3 -m venv venv
-RUN source venv/bin/activate ; pip3 install PyMLX90614 smbus2 RPi.GPIO
+WORKDIR /usr/src/ros2ws/src
+RUN git clone -b ros2 https://github.com/Slamtec/rplidar_ros.git
+WORKDIR /usr/src/ros2ws
+COPY src/roboquest_addons src/roboquest_addons
+COPY src/rq_msgs src/rq_msgs
+RUN source /opt/ros/humble/setup.bash \
+    && colcon build --symlink-install
 
 ENTRYPOINT ["/bin/bash", "--login"]
 #CMD ["/usr/src/ros2ws/src/roboquest_addons/scripts/start.sh"]

--- a/ros2ws/Dockerfile.roboquest_autonomy_demo
+++ b/ros2ws/Dockerfile.roboquest_autonomy_demo
@@ -11,17 +11,14 @@ RUN ln -sf /bin/bash /bin/sh
 
 SHELL ["/bin/bash", "--login", "-c"]
 
-RUN apt-get update \
-    && apt-get upgrade -y
+RUN apt-get update
+RUN apt-get upgrade -y
 RUN apt-get install -y \
+    ros-humble-xacro \
+    ros-humble-apriltag-ros \
+    ros-humble-joint-state-publisher \
+    ros-humble-robot-state-publisher \
     vim
-
-#
-# For recognizing APRIL tags.
-#
-# requires FROM ros:humble-ros-base
-WORKDIR /usr/src/ros2ws
-RUN apt-get install -y ros-humble-apriltag-ros
 
 #
 # For the SLAMTEC RPLiDAR unit.

--- a/ros2ws/Dockerfile.roboquest_core
+++ b/ros2ws/Dockerfile.roboquest_core
@@ -45,10 +45,10 @@ WORKDIR /root/.ros/camera_info
 #
 # These depend on the specific cameras connected to a specific port
 #
-COPY src/roboquest_core/config/ov5647_1296x972_calibration.yaml ov5647__base_soc_i2c0mux_i2c_1_ov5647_36_1296x972.yaml
-COPY src/roboquest_core/config/ov5647CSI_1296x972_calibration.yaml ov5647__base_soc_i2c0mux_i2c_1_ov5647_36_1296x972.yaml
+# The ArduCam RaspPi camera module connected to the CSI port.
+COPY src/roboquest_core/config/ov5647_640x480_calibration.yaml ov5647__base_soc_i2c0mux_i2c_1_ov5647_36_640x480.yaml
+# The ArduCam USB module
 COPY src/roboquest_core/config/arducam_1296x972_calibration.yaml ArducamUSBCamera_ArducamUSB__base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_3_1_0_0c45_6366_1296x972.yaml
-COPY src/roboquest_core/config/quickcampro9000.yaml UVCCamera_046d_0990___base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_3_1_0_046d_0990_1600x1200.yaml
 
 WORKDIR /usr/src/ros2ws
 RUN mkdir src

--- a/ros2ws/Dockerfile.roboquest_core
+++ b/ros2ws/Dockerfile.roboquest_core
@@ -1,7 +1,7 @@
 FROM ros:humble-ros-base
 
 # see https://github.com/billmania/roboquest/wiki/roboquest-wiki
-LABEL version="25"
+LABEL version="25.1rc3"
 # see https://github.com/billmania/roboquest/wiki/roboquest-wiki
 
 LABEL description="ROS2 RoboQuest core"
@@ -45,8 +45,9 @@ WORKDIR /root/.ros/camera_info
 #
 # These depend on the specific cameras connected to a specific port
 #
-COPY src/roboquest_core/config/ov5647_1280x960_calibration.yaml ov5647__base_soc_i2c0mux_i2c_1_ov5647_36_1280x960.yaml
-COPY src/roboquest_core/config/arducam_1280x720_calibration.yaml ArducamUSBCamera_ArducamUSB__base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_3_1_0_0c45_6366_1280x720.yaml
+COPY src/roboquest_core/config/ov5647_1296x972_calibration.yaml ov5647__base_soc_i2c0mux_i2c_1_ov5647_36_1296x972.yaml
+COPY src/roboquest_core/config/ov5647CSI_1296x972_calibration.yaml ov5647__base_soc_i2c0mux_i2c_1_ov5647_36_1296x972.yaml
+COPY src/roboquest_core/config/arducam_1296x972_calibration.yaml ArducamUSBCamera_ArducamUSB__base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_3_1_0_0c45_6366_1296x972.yaml
 COPY src/roboquest_core/config/quickcampro9000.yaml UVCCamera_046d_0990___base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_3_1_0_046d_0990_1600x1200.yaml
 
 WORKDIR /usr/src/ros2ws

--- a/ros2ws/Dockerfile.rpi-image-gen
+++ b/ros2ws/Dockerfile.rpi-image-gen
@@ -1,0 +1,24 @@
+FROM arm64v8/debian:trixie-slim
+
+LABEL version="1"
+LABEL description="rpi-image-gen"
+LABEL maintainer="Bill Mania <bill@manialabs.us>"
+ARG DEBIAN_FRONTEND=noninteractive
+ARG BASEDIR="/opt"
+
+RUN apt-get update \
+    && apt-get dist-upgrade -y
+
+RUN apt-get install -y \
+    git \
+    tree \
+    vim
+
+WORKDIR $BASEDIR
+RUN git clone https://github.com/raspberrypi/rpi-image-gen.git
+
+WORKDIR $BASEDIR/rpi-image-gen
+RUN ./install_deps.sh
+COPY src/roboquest_addons/rpi-image-gen $BASEDIR/rpi-image-gen/
+
+ENTRYPOINT ["/bin/bash", "--login"]


### PR DESCRIPTION
Lots of stuff to enable using the ArduCam CSI camera with the rq_addons APRIL tag functionality.

A Dockerfile for creating microSD images for use with the rpi-image-gen utility.