### PR TITLE
Pull the roboquest_addons repo directly from git

### DIFF
--- a/ros2ws/Dockerfile.rpi-image-gen
+++ b/ros2ws/Dockerfile.rpi-image-gen
@@ -1,10 +1,9 @@
 FROM arm64v8/debian:trixie-slim
 
-LABEL version="1"
+LABEL version="2"
 LABEL description="rpi-image-gen"
 LABEL maintainer="Bill Mania <bill@manialabs.us>"
 ARG DEBIAN_FRONTEND=noninteractive
-ARG BASEDIR="/opt"
 
 RUN apt-get update \
     && apt-get dist-upgrade -y
@@ -14,11 +13,13 @@ RUN apt-get install -y \
     tree \
     vim
 
-WORKDIR $BASEDIR
+WORKDIR /opt
 RUN git clone https://github.com/raspberrypi/rpi-image-gen.git
 
-WORKDIR $BASEDIR/rpi-image-gen
+WORKDIR /opt/rpi-image-gen
 RUN ./install_deps.sh
-COPY src/roboquest_addons/rpi-image-gen $BASEDIR/rpi-image-gen/
+WORKDIR /opt
+RUN git clone https://github.com/billmania/roboquest_addons.git
+RUN ln -s /opt/roboquest_addons/rpi-image-gen/rq-lidar-april /opt/rpi-image-gen/rq-lidar-april
 
 ENTRYPOINT ["/bin/bash", "--login"]


### PR DESCRIPTION
Instead of copying the content of the repo from a local directory, pull it directly from git. The source code for a particular image build can still be copied into the running container.

https://github.com/billmania/roboquest/issues/28